### PR TITLE
Release v1.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateway",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.9.0",

--- a/src/components/block/AllAreaPieChart.tsx
+++ b/src/components/block/AllAreaPieChart.tsx
@@ -6,7 +6,13 @@ import apiClient from "#/axios-config";
 import ReactApexChart from "react-apexcharts";
 import { ApexOptions } from "apexcharts";
 
-import { Typography, Box, CircularProgress, List, ListItem } from "@mui/material";
+import {
+  Typography,
+  Box,
+  CircularProgress,
+  List,
+  ListItem,
+} from "@mui/material";
 
 import { handleApiError } from "#/components/lib/commonFunction";
 import useDeviceWidth from "#/components/lib/useDeviceWidth";
@@ -14,7 +20,9 @@ import useDeviceWidth from "#/components/lib/useDeviceWidth";
 const AllAreaPieChart: React.VFC = () => {
   const { largerThanSM, largerThanLG } = useDeviceWidth();
   const token = useAtomValue(tokenAtom);
-  const [allAreaCount, setAllAreaCount] = useState<{ guest_type: string; count: number; }[]>([]);
+  const [allAreaCount, setAllAreaCount] = useState<
+    { guest_type: string; count: number }[]
+  >([]);
   const [allAreaChartCategories, setAllAreaChartCategories] = useState<
     string[]
   >(["保護者", "生徒", "教員"]);
@@ -78,32 +86,52 @@ const AllAreaPieChart: React.VFC = () => {
     },
   };
 
-  const EachGuestTypeListItem: React.VFC<{ guest_type: string; type_name: string; }> = ({ guest_type, type_name }) => {
+  const EachGuestTypeListItem: React.VFC<{
+    guest_type: string;
+    type_name: string;
+  }> = ({ guest_type, type_name }) => {
     return (
-      <ListItem divider sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+      <ListItem
+        divider
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
         <Typography variant="body1">{type_name}</Typography>
-        <Typography variant="body1"><span style={{ fontSize: "1.5rem", fontWeight: 800 }}>{allAreaCount.filter(v => v.guest_type === guest_type)[0]?.count || 0}</span> 人</Typography>
+        <Typography variant="body1">
+          <span style={{ fontSize: "1.5rem", fontWeight: 800 }}>
+            {allAreaCount.filter((v) => v.guest_type === guest_type)[0]
+              ?.count || 0}
+          </span>{" "}
+          人
+        </Typography>
       </ListItem>
-    )
-  }
+    );
+  };
   return (
     <>
-      <Box sx={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        height: 30,
-      }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          height: 30,
+        }}
+      >
         <Typography variant="h3">全体の滞在状況</Typography>
         {loading && <CircularProgress size={25} thickness={6} />}
       </Box>
       {allAreaCount.length !== 0 ? (
-        <Box sx={{
-          display: "flex",
-          flexDirection: (largerThanSM && !largerThanLG) ? "row" : "column",
-          justifyContent: "center",
-          alignItems: "center",
-        }}>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: largerThanSM && !largerThanLG ? "row" : "column",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
           <Box sx={{ flexGrow: 1 }}>
             <ReactApexChart
               options={options}
@@ -116,14 +144,28 @@ const AllAreaPieChart: React.VFC = () => {
             <EachGuestTypeListItem guest_type="student" type_name="生徒" />
             <EachGuestTypeListItem guest_type="teacher" type_name="教員" />
             <EachGuestTypeListItem guest_type="other" type_name="その他" />
-            <ListItem divider sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <ListItem
+              divider
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+              }}
+            >
               <Typography variant="h4">総数</Typography>
-              <Typography variant="body1"><span style={{ fontSize: "2rem", fontWeight: 800 }}>{allAreaCount.reduce((a, c) => a + c.count, 0) || 0}</span> 人</Typography>
+              <Typography variant="body1">
+                <span style={{ fontSize: "2rem", fontWeight: 800 }}>
+                  {allAreaCount.reduce((a, c) => a + c.count, 0) || 0}
+                </span>{" "}
+                人
+              </Typography>
             </ListItem>
           </List>
         </Box>
       ) : loading ? (
-        <Typography variant="body1" sx={{ p: 2 }}>読み込み中...</Typography>
+        <Typography variant="body1" sx={{ p: 2 }}>
+          読み込み中...
+        </Typography>
       ) : (
         <Typography variant="body1" sx={{ p: 2 }}>
           現在校内に来場者はいません。

--- a/src/components/block/AllAreaPieChart.tsx
+++ b/src/components/block/AllAreaPieChart.tsx
@@ -6,20 +6,22 @@ import apiClient from "#/axios-config";
 import ReactApexChart from "react-apexcharts";
 import { ApexOptions } from "apexcharts";
 
-import { Typography, Box, CircularProgress } from "@mui/material";
+import { Typography, Box, CircularProgress, List, ListItem } from "@mui/material";
 
 import { handleApiError } from "#/components/lib/commonFunction";
+import useDeviceWidth from "#/components/lib/useDeviceWidth";
 
 const AllAreaPieChart: React.VFC = () => {
+  const { largerThanSM, largerThanLG } = useDeviceWidth();
   const token = useAtomValue(tokenAtom);
-  const [allAreaTotalCount, setAllAreaTotalCount] = useState<number>(0);
+  const [allAreaCount, setAllAreaCount] = useState<{ guest_type: string; count: number; }[]>([]);
   const [allAreaChartCategories, setAllAreaChartCategories] = useState<
     string[]
   >(["保護者", "生徒", "教員"]);
   const [allAreaChartSeries, setAllAreaChartSeries] = useState<number[]>([0]);
   const [loading, setLoading] = useState<boolean>(false);
 
-  useEffect(() => {
+  const getAllAreaInfo = () => {
     if (token) {
       setLoading(true);
       apiClient(process.env.REACT_APP_API_BASE_URL)
@@ -27,7 +29,7 @@ const AllAreaPieChart: React.VFC = () => {
           headers: { Authorization: `Bearer ${token}` },
         })
         .then((res) => {
-          setAllAreaTotalCount(res.reduce((a, c) => a + c.count, 0));
+          setAllAreaCount(res);
           setAllAreaChartCategories(
             res.map((v) => {
               switch (v.guest_type) {
@@ -51,6 +53,17 @@ const AllAreaPieChart: React.VFC = () => {
           setLoading(false);
         });
     }
+  };
+
+  // 15秒ごとに自動で取得
+  useEffect(() => {
+    getAllAreaInfo();
+    const intervalId = setInterval(() => {
+      getAllAreaInfo();
+    }, 5 * 60 * 1000);
+    return () => {
+      clearInterval(intervalId);
+    };
   }, []);
 
   const options: ApexOptions = {
@@ -65,27 +78,52 @@ const AllAreaPieChart: React.VFC = () => {
     },
   };
 
+  const EachGuestTypeListItem: React.VFC<{ guest_type: string; type_name: string; }> = ({ guest_type, type_name }) => {
+    return (
+      <ListItem divider sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="body1">{type_name}</Typography>
+        <Typography variant="body1"><span style={{ fontSize: "1.5rem", fontWeight: 800 }}>{allAreaCount.filter(v => v.guest_type === guest_type)[0]?.count || 0}</span> 人</Typography>
+      </ListItem>
+    )
+  }
   return (
     <>
-      <Typography variant="h3">全体の滞在状況</Typography>
-      {allAreaTotalCount ? (
-        <>
-          <Typography sx={{ p: 2 }}>
-            校内滞在者数 {allAreaTotalCount}人
-          </Typography>
-          <Box sx={{ margin: "auto" }}>
+      <Box sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        height: 30,
+      }}>
+        <Typography variant="h3">全体の滞在状況</Typography>
+        {loading && <CircularProgress size={25} thickness={6} />}
+      </Box>
+      {allAreaCount ? (
+        <Box sx={{
+          display: "flex",
+          flexDirection: (largerThanSM && !largerThanLG) ? "row" : "column",
+          justifyContent: "center",
+          alignItems: "center",
+        }}>
+          <Box sx={{ flexGrow: 1 }}>
             <ReactApexChart
               options={options}
               series={allAreaChartSeries}
               type="pie"
             />
           </Box>
-        </>
-      ) : loading ? (
-        <Box sx={{ display: "flex", alignItems: "center", gap: 2, p: 2 }}>
-          <CircularProgress size={25} thickness={6} />
-          <Typography variant="body1">読み込み中...</Typography>
+          <List dense sx={{ width: "100%", maxWidth: 350 }}>
+            <EachGuestTypeListItem guest_type="family" type_name="保護者" />
+            <EachGuestTypeListItem guest_type="student" type_name="生徒" />
+            <EachGuestTypeListItem guest_type="teacher" type_name="教員" />
+            <EachGuestTypeListItem guest_type="other" type_name="その他" />
+            <ListItem divider sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <Typography variant="h4">総数</Typography>
+              <Typography variant="body1"><span style={{ fontSize: "2rem", fontWeight: 800 }}>{allAreaCount.reduce((a, c) => a + c.count, 0) || 0}</span> 人</Typography>
+            </ListItem>
+          </List>
         </Box>
+      ) : loading ? (
+        <Typography variant="body1" sx={{ p: 2 }}>読み込み中...</Typography>
       ) : (
         <Typography variant="body1" sx={{ p: 2 }}>
           現在校内に来場者はいません。

--- a/src/components/block/AllAreaPieChart.tsx
+++ b/src/components/block/AllAreaPieChart.tsx
@@ -97,7 +97,7 @@ const AllAreaPieChart: React.VFC = () => {
         <Typography variant="h3">全体の滞在状況</Typography>
         {loading && <CircularProgress size={25} thickness={6} />}
       </Box>
-      {allAreaCount ? (
+      {allAreaCount.length !== 0 ? (
         <Box sx={{
           display: "flex",
           flexDirection: (largerThanSM && !largerThanLG) ? "row" : "column",

--- a/src/components/block/ExhibitCurrentGuestList.tsx
+++ b/src/components/block/ExhibitCurrentGuestList.tsx
@@ -20,7 +20,13 @@ import {
   Snackbar,
   Typography,
 } from "@mui/material";
-import { DataGrid, GridColDef, GridRowId, GridToolbar, jaJP } from "@mui/x-data-grid";
+import {
+  DataGrid,
+  GridColDef,
+  GridRowId,
+  GridToolbar,
+  jaJP,
+} from "@mui/x-data-grid";
 
 import { handleApiError } from "#/components/lib/commonFunction";
 import useDeviceWidth from "#/components/lib/useDeviceWidth";
@@ -66,10 +72,10 @@ const ExhibitCurrentGuestList: React.VFC<{ exhibit_id: string }> = ({
                 v.guest_type === "student"
                   ? "生徒"
                   : v.guest_type === "teacher"
-                    ? "教員"
-                    : v.guest_type === "family"
-                      ? "保護者"
-                      : "その他",
+                  ? "教員"
+                  : v.guest_type === "family"
+                  ? "保護者"
+                  : "その他",
               enter_at: moment(v.enter_at).format("MM/DD HH:mm:ss"),
             };
           });
@@ -154,7 +160,7 @@ const ExhibitCurrentGuestList: React.VFC<{ exhibit_id: string }> = ({
   };
 
   const CustomGridToolbar: React.VFC = () => {
-    return <GridToolbar sx={{ gap: 1 }} />
+    return <GridToolbar sx={{ gap: 1 }} />;
   };
 
   return (
@@ -204,7 +210,7 @@ const ExhibitCurrentGuestList: React.VFC<{ exhibit_id: string }> = ({
               ...jaJP.components.MuiDataGrid.defaultProps.localeText,
               noRowsLabel: "現在この展示に滞在中のゲストはいません。",
             }}
-            sx={{ '& *': { my: 0, minHeight: 10 } }}
+            sx={{ "& *": { my: 0, minHeight: 10 } }}
           />
         </Grid>
       </Grid>

--- a/src/components/block/ExhibitCurrentGuestList.tsx
+++ b/src/components/block/ExhibitCurrentGuestList.tsx
@@ -20,7 +20,7 @@ import {
   Snackbar,
   Typography,
 } from "@mui/material";
-import { DataGrid, GridColDef, GridRowId } from "@mui/x-data-grid";
+import { DataGrid, GridColDef, GridRowId, GridToolbar, jaJP } from "@mui/x-data-grid";
 
 import { handleApiError } from "#/components/lib/commonFunction";
 import useDeviceWidth from "#/components/lib/useDeviceWidth";
@@ -66,10 +66,10 @@ const ExhibitCurrentGuestList: React.VFC<{ exhibit_id: string }> = ({
                 v.guest_type === "student"
                   ? "生徒"
                   : v.guest_type === "teacher"
-                  ? "教員"
-                  : v.guest_type === "family"
-                  ? "保護者"
-                  : "その他",
+                    ? "教員"
+                    : v.guest_type === "family"
+                      ? "保護者"
+                      : "その他",
               enter_at: moment(v.enter_at).format("MM/DD HH:mm:ss"),
             };
           });
@@ -153,6 +153,10 @@ const ExhibitCurrentGuestList: React.VFC<{ exhibit_id: string }> = ({
     );
   };
 
+  const CustomGridToolbar: React.VFC = () => {
+    return <GridToolbar sx={{ gap: 1 }} />
+  };
+
   return (
     <>
       <Grid container spacing={1} sx={{ width: "100%" }}>
@@ -187,18 +191,19 @@ const ExhibitCurrentGuestList: React.VFC<{ exhibit_id: string }> = ({
         </Grid>
         <Grid item xs={12} sx={{ height: "100%" }}>
           <DataGrid
+            components={{ Toolbar: CustomGridToolbar }}
             autoHeight
             rows={rows}
             columns={columns}
-            rowHeight={50}
             checkboxSelection
-            hideFooter
             onSelectionModelChange={(newSelection) => {
               setSelectedGuestList(newSelection);
             }}
             localeText={{
-              noRowsLabel: "現在この展示に滞在中のゲストはいません",
+              ...jaJP.components.MuiDataGrid.defaultProps.localeText,
+              noRowsLabel: "現在この展示に滞在中のゲストはいません。",
             }}
+            sx={{ '& *': { my: 0, minHeight: 10 } }}
           />
         </Grid>
       </Grid>

--- a/src/components/block/ExhibitCurrentGuestList.tsx
+++ b/src/components/block/ExhibitCurrentGuestList.tsx
@@ -199,6 +199,7 @@ const ExhibitCurrentGuestList: React.VFC<{ exhibit_id: string }> = ({
             onSelectionModelChange={(newSelection) => {
               setSelectedGuestList(newSelection);
             }}
+            pageSize={25}
             localeText={{
               ...jaJP.components.MuiDataGrid.defaultProps.localeText,
               noRowsLabel: "現在この展示に滞在中のゲストはいません。",

--- a/src/components/block/RealtimeLog.tsx
+++ b/src/components/block/RealtimeLog.tsx
@@ -6,7 +6,6 @@ import apiClient from "#/axios-config";
 import moment, { Moment } from "moment";
 
 import {
-  Box,
   CircularProgress,
   FormControlLabel,
   Grid,
@@ -106,24 +105,16 @@ const RealtimeLog: React.VFC = () => {
 
   return (
     <Grid container>
-      <Grid item xs={12}>
-        <Grid
-          container
-          sx={{
-            alignItems: "center",
-            justifyContent: "space-between",
-            height: 30,
-          }}
-        >
-          <Grid item>
-            <Tooltip title="15秒更新">
-              <Typography variant="h3">リアルタイムログ</Typography>
-            </Tooltip>
-          </Grid>
-          <Grid item>
-            {loading && <CircularProgress size={25} thickness={6} />}
-          </Grid>
-        </Grid>
+      <Grid item xs={12} sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        height: 30,
+      }}>
+        <Tooltip title="15秒更新">
+          <Typography variant="h3">リアルタイムログ</Typography>
+        </Tooltip>
+        {loading && <CircularProgress size={25} thickness={6} />}
       </Grid>
       {activityList.length !== 0 ? (
         <>
@@ -176,14 +167,14 @@ const RealtimeLog: React.VFC = () => {
                     {largerThanSM && (
                       <Grid item sm={4}>
                         <ListItemText
-                          secondary={
+                          secondary={v.activity_id}
+                          secondaryTypographyProps={{ p: 0 }}
+                        >
+                          {
                             maskId
                               ? v.guest_id.slice(0, 6) + "____"
                               : v.guest_id
                           }
-                          secondaryTypographyProps={{ sx: { p: 0 } }}
-                        >
-                          {v.activity_id}
                         </ListItemText>
                       </Grid>
                     )}
@@ -213,10 +204,7 @@ const RealtimeLog: React.VFC = () => {
           </Grid>
         </>
       ) : loading ? (
-        <Box sx={{ display: "flex", alignItems: "center", gap: 2, p: 2 }}>
-          <CircularProgress size={25} thickness={6} />
-          <Typography variant="body1">読み込み中...</Typography>
-        </Box>
+        <Typography variant="body1" sx={{ p: 2 }}>読み込み中...</Typography>
       ) : (
         <Typography variant="body1" sx={{ m: 2 }}>
           データがありません。

--- a/src/components/block/RealtimeLog.tsx
+++ b/src/components/block/RealtimeLog.tsx
@@ -66,9 +66,6 @@ const RealtimeLog: React.VFC = () => {
         })
         .then((res) => {
           const newActivityList = res
-            .map((v) => {
-              return { ...v, activity_type: "enter" };
-            })
             .sort((a, b) => {
               if (a.timestamp < b.timestamp) {
                 return 1;

--- a/src/components/block/RealtimeLog.tsx
+++ b/src/components/block/RealtimeLog.tsx
@@ -65,14 +65,13 @@ const RealtimeLog: React.VFC = () => {
           headers: { Authorization: `Bearer ${token}` },
         })
         .then((res) => {
-          const newActivityList = res
-            .sort((a, b) => {
-              if (a.timestamp < b.timestamp) {
-                return 1;
-              } else {
-                return -1;
-              }
-            });
+          const newActivityList = res.sort((a, b) => {
+            if (a.timestamp < b.timestamp) {
+              return 1;
+            } else {
+              return -1;
+            }
+          });
           setActivityList([...activityList, ...newActivityList]);
           setLastUpdate(moment());
         })
@@ -102,12 +101,16 @@ const RealtimeLog: React.VFC = () => {
 
   return (
     <Grid container>
-      <Grid item xs={12} sx={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        height: 30,
-      }}>
+      <Grid
+        item
+        xs={12}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          height: 30,
+        }}
+      >
         <Tooltip title="15秒更新">
           <Typography variant="h3">リアルタイムログ</Typography>
         </Tooltip>
@@ -167,11 +170,9 @@ const RealtimeLog: React.VFC = () => {
                           secondary={v.activity_id}
                           secondaryTypographyProps={{ p: 0 }}
                         >
-                          {
-                            maskId
-                              ? v.guest_id.slice(0, 6) + "____"
-                              : v.guest_id
-                          }
+                          {maskId
+                            ? v.guest_id.slice(0, 6) + "____"
+                            : v.guest_id}
                         </ListItemText>
                       </Grid>
                     )}
@@ -201,7 +202,9 @@ const RealtimeLog: React.VFC = () => {
           </Grid>
         </>
       ) : loading ? (
-        <Typography variant="body1" sx={{ p: 2 }}>読み込み中...</Typography>
+        <Typography variant="body1" sx={{ p: 2 }}>
+          読み込み中...
+        </Typography>
       ) : (
         <Typography variant="body1" sx={{ m: 2 }}>
           データがありません。

--- a/src/components/block/Scanner.tsx
+++ b/src/components/block/Scanner.tsx
@@ -82,7 +82,7 @@ const Scanner: React.VFC<ScannerProps> = ({ handleScan }) => {
       )
       .then((devices) => {
         setDeviceList(devices);
-        if (currentDeviceId === "") {
+        if (currentDeviceId === "" && devices.length !== 0) {
           setCurrentDeviceId(devices[0].deviceId);
         }
       })
@@ -150,6 +150,9 @@ const Scanner: React.VFC<ScannerProps> = ({ handleScan }) => {
           reason =
             "カメラを使用する権限がありません。お使いのブラウザの設定を確認してください。";
           break;
+        case "NotFoundError":
+          reason = "この端末には利用可能なカメラがありません。";
+          break;
         case "OverconstrainedError":
           reason = "この端末には利用可能なカメラがありません。";
           break;
@@ -183,7 +186,6 @@ const Scanner: React.VFC<ScannerProps> = ({ handleScan }) => {
   };
 
   const onClickChangeCameraIcon = () => {
-    setScannerStatus("loading");
     getCameraDeviceList();
     if (deviceList.length === 2) {
       const newCurrentDevice = deviceList.find((v) => {
@@ -197,10 +199,10 @@ const Scanner: React.VFC<ScannerProps> = ({ handleScan }) => {
           newCurrentDevice.deviceId
         );
         setCurrentDeviceId(newCurrentDevice.deviceId);
+        setScannerStatus("loading");
         setRefreshQrReader(false);
       }
     } else {
-      setScannerStatus("waiting");
       setSelectCameraModalOpen(true);
     }
   };

--- a/src/components/block/Scanner.tsx
+++ b/src/components/block/Scanner.tsx
@@ -105,10 +105,10 @@ const Scanner: React.VFC<ScannerProps> = ({ handleScan }) => {
     }
   }, [location]);
 
-  // out of memory の対策として、2 分 30 秒ごとに react-qr-reader を unmount して、直後に mount している
+  // out of memory の対策として、2 分ごとに react-qr-reader を unmount して、直後に mount している
   // https://github.com/afes-website/cappuccino-app/blob/d0201aa5506e6b3aa7c3cc887171d83b0e773b18/src/components/QRScanner.tsx#L146
   const [refreshQrReader, setRefreshQrReader] = useState(true);
-  const interval = isAndroid() ? 30 * 1000 : 2.5 * 60 * 1000;
+  const interval = isAndroid() ? 30 * 1000 : 2 * 60 * 1000;
   useEffect(() => {
     const intervalId = setInterval(() => {
       setScannerStatus("loading");

--- a/src/components/block/SelectExhibit.tsx
+++ b/src/components/block/SelectExhibit.tsx
@@ -41,19 +41,17 @@ const SelectExhibit: React.VFC<SelectExhibitProps> = ({
           },
         })
         .then((res) => {
+          const newExhibitList = [];
           if (profile.user_type === "executive") {
-            const executiveExhibitList = res.filter(
+            newExhibitList.push(...res.filter(
               (v) => v.exhibit_type === "stage" || v.exhibit_type === "other"
-            );
-            setExhibitList(executiveExhibitList);
-            if (currentExhibit === "") {
-              setCurrentExhibit(executiveExhibitList[0].exhibit_id);
-            }
+            ));
           } else {
-            setExhibitList(res);
-            if (currentExhibit === "") {
-              setCurrentExhibit(res[0].exhibit_id);
-            }
+            newExhibitList.push(...res);
+          }
+          setExhibitList(newExhibitList);
+          if (currentExhibit === "" || newExhibitList.filter(exhibit => exhibit.exhibit_id === currentExhibit).length === 0) {
+            setCurrentExhibit(newExhibitList[0].exhibit_id);
           }
           ReactGA.event({
             category: "exhibit",

--- a/src/components/block/SelectExhibit.tsx
+++ b/src/components/block/SelectExhibit.tsx
@@ -46,10 +46,14 @@ const SelectExhibit: React.VFC<SelectExhibitProps> = ({
               (v) => v.exhibit_type === "stage" || v.exhibit_type === "other"
             );
             setExhibitList(executiveExhibitList);
-            setCurrentExhibit(executiveExhibitList[0].exhibit_id);
+            if (currentExhibit === "") {
+              setCurrentExhibit(executiveExhibitList[0].exhibit_id);
+            }
           } else {
             setExhibitList(res);
-            setCurrentExhibit(res[0].exhibit_id);
+            if (currentExhibit === "") {
+              setCurrentExhibit(res[0].exhibit_id);
+            }
           }
           ReactGA.event({
             category: "exhibit",

--- a/src/components/block/SelectExhibit.tsx
+++ b/src/components/block/SelectExhibit.tsx
@@ -43,14 +43,21 @@ const SelectExhibit: React.VFC<SelectExhibitProps> = ({
         .then((res) => {
           const newExhibitList = [];
           if (profile.user_type === "executive") {
-            newExhibitList.push(...res.filter(
-              (v) => v.exhibit_type === "stage" || v.exhibit_type === "other"
-            ));
+            newExhibitList.push(
+              ...res.filter(
+                (v) => v.exhibit_type === "stage" || v.exhibit_type === "other"
+              )
+            );
           } else {
             newExhibitList.push(...res);
           }
           setExhibitList(newExhibitList);
-          if (currentExhibit === "" || newExhibitList.filter(exhibit => exhibit.exhibit_id === currentExhibit).length === 0) {
+          if (
+            currentExhibit === "" ||
+            newExhibitList.filter(
+              (exhibit) => exhibit.exhibit_id === currentExhibit
+            ).length === 0
+          ) {
             setCurrentExhibit(newExhibitList[0].exhibit_id);
           }
           ReactGA.event({

--- a/src/components/lib/commonFunction.ts
+++ b/src/components/lib/commonFunction.ts
@@ -67,7 +67,11 @@ export const reservationIdValidation = (reservation_id: string) => {
 export const handleApiError = (error: AxiosError, name: string) => {
   console.log(error);
   const env = process.env.REACT_APP_ENV;
-  if (env && (env === "production" || env === "develop") && error?.code !== "401") {
+  if (
+    env &&
+    (env === "production" || env === "develop") &&
+    error?.code !== "401"
+  ) {
     ReactGA.event({
       category: `error_${name}`,
       action: error.message,

--- a/src/components/lib/commonFunction.ts
+++ b/src/components/lib/commonFunction.ts
@@ -67,7 +67,7 @@ export const reservationIdValidation = (reservation_id: string) => {
 export const handleApiError = (error: AxiosError, name: string) => {
   console.log(error);
   const env = process.env.REACT_APP_ENV;
-  if (env && (env === "production" || env === "develop")) {
+  if (env && (env === "production" || env === "develop") && error?.code !== "401") {
     ReactGA.event({
       category: `error_${name}`,
       action: error.message,

--- a/src/components/lib/commonFunction.ts
+++ b/src/components/lib/commonFunction.ts
@@ -87,6 +87,7 @@ export const handleApiError = (error: AxiosError, name: string) => {
         "-" +
         (process.env.REACT_APP_ENV || "unknown");
       content += "version  : " + version + "\n";
+      content += `UA       : ${window.navigator.userAgent}\n`;
       const userId = localStorage.getItem("user_id");
       if (userId) {
         content += "user_id  : " + userId + "\n";
@@ -129,10 +130,11 @@ export const sendLog = (message: string, err?: unknown) => {
       let content =
         "```timestamp: " + moment().format("MM/DD HH:mm:ss SSS") + "\n";
       const version =
-        (process.env.REACT_APP_VERSION || "unknown") +
+        generalProps.app_version +
         "-" +
         (process.env.REACT_APP_ENV || "unknown");
       content += `version  : ${version}\n`;
+      content += `UA       : ${window.navigator.userAgent}\n`;
       const userId = localStorage.getItem("user_id");
       if (userId) {
         content += `user_id  : ${userId}\n`;

--- a/src/components/lib/generalProps.ts
+++ b/src/components/lib/generalProps.ts
@@ -1,6 +1,6 @@
 const generalProps = {
-  app_version: "1.9.5",
-  version_date: "2022/08/31",
+  app_version: "1.9.6",
+  version_date: "2022/09/09",
   time_part: [
     {
       part_name: "全時間帯",

--- a/src/components/lib/useDeviceWidth.ts
+++ b/src/components/lib/useDeviceWidth.ts
@@ -5,7 +5,8 @@ const useDeviceWidth = () => {
   const theme = useTheme();
   const largerThanSM = useMediaQuery(theme.breakpoints.up("sm"));
   const largerThanMD = useMediaQuery(theme.breakpoints.up("md"));
-  return { largerThanSM, largerThanMD };
+  const largerThanLG = useMediaQuery(theme.breakpoints.up("lg"));
+  return { largerThanSM, largerThanMD, largerThanLG };
 };
 
 export default useDeviceWidth;

--- a/src/components/page/Admin/CheckGuest.tsx
+++ b/src/components/page/Admin/CheckGuest.tsx
@@ -177,7 +177,9 @@ const AdminCheckGuest: React.VFC = () => {
             <Card variant="outlined" sx={{ p: 2 }}>
               <Typography variant="h3">行動履歴</Typography>
               {guestActivity.length === 0 ? (
-                <Typography variant="body1" sx={{ p: 2 }}>このゲストの入退室記録がありません。</Typography>
+                <Typography variant="body1" sx={{ p: 2 }}>
+                  このゲストの入退室記録がありません。
+                </Typography>
               ) : (
                 <Timeline position="alternate">
                   {guestActivity.map((v, i) => {
@@ -189,7 +191,9 @@ const AdminCheckGuest: React.VFC = () => {
                         <TimelineSeparator>
                           <TimelineDot color="primary" />
                           {v.activity_type === "enter" ? (
-                            <TimelineConnector sx={{ bgcolor: "primary.main" }} />
+                            <TimelineConnector
+                              sx={{ bgcolor: "primary.main" }}
+                            />
                           ) : (
                             <TimelineConnector />
                           )}
@@ -234,10 +238,10 @@ const AdminCheckGuest: React.VFC = () => {
                     {guestInfo.guest_type === "family"
                       ? "保護者"
                       : guestInfo.guest_type === "student"
-                        ? "生徒"
-                        : guestInfo.guest_type === "teacher"
-                          ? "教員"
-                          : "その他"}
+                      ? "生徒"
+                      : guestInfo.guest_type === "teacher"
+                      ? "教員"
+                      : "その他"}
                   </ListItemText>
                 </ListItem>
                 <ListItem>

--- a/src/components/page/Admin/CheckGuest.tsx
+++ b/src/components/page/Admin/CheckGuest.tsx
@@ -176,32 +176,36 @@ const AdminCheckGuest: React.VFC = () => {
           <Grid item xs={12} md={6}>
             <Card variant="outlined" sx={{ p: 2 }}>
               <Typography variant="h3">行動履歴</Typography>
-              <Timeline position="alternate">
-                {guestActivity.map((v, i) => {
-                  return (
-                    <TimelineItem key={i}>
-                      <TimelineOppositeContent color="text.secondary">
-                        {v.datetime.format("MM/DD HH:mm:ss")}
-                      </TimelineOppositeContent>
-                      <TimelineSeparator>
-                        <TimelineDot color="primary" />
+              {guestActivity.length === 0 ? (
+                <Typography variant="body1" sx={{ p: 2 }}>このゲストの入退室記録がありません。</Typography>
+              ) : (
+                <Timeline position="alternate">
+                  {guestActivity.map((v, i) => {
+                    return (
+                      <TimelineItem key={i}>
+                        <TimelineOppositeContent color="text.secondary">
+                          {v.datetime.format("MM/DD HH:mm:ss")}
+                        </TimelineOppositeContent>
+                        <TimelineSeparator>
+                          <TimelineDot color="primary" />
+                          {v.activity_type === "enter" ? (
+                            <TimelineConnector sx={{ bgcolor: "primary.main" }} />
+                          ) : (
+                            <TimelineConnector />
+                          )}
+                        </TimelineSeparator>
                         {v.activity_type === "enter" ? (
-                          <TimelineConnector sx={{ bgcolor: "primary.main" }} />
+                          <TimelineContent>
+                            {getExhibitName(v.exhibit_id)}
+                          </TimelineContent>
                         ) : (
-                          <TimelineConnector />
+                          <TimelineContent>退室</TimelineContent>
                         )}
-                      </TimelineSeparator>
-                      {v.activity_type === "enter" ? (
-                        <TimelineContent>
-                          {getExhibitName(v.exhibit_id)}
-                        </TimelineContent>
-                      ) : (
-                        <TimelineContent>退室</TimelineContent>
-                      )}
-                    </TimelineItem>
-                  );
-                })}
-              </Timeline>
+                      </TimelineItem>
+                    );
+                  })}
+                </Timeline>
+              )}
             </Card>
           </Grid>
           <Grid item xs={12} md={6}>
@@ -230,10 +234,10 @@ const AdminCheckGuest: React.VFC = () => {
                     {guestInfo.guest_type === "family"
                       ? "保護者"
                       : guestInfo.guest_type === "student"
-                      ? "生徒"
-                      : guestInfo.guest_type === "teacher"
-                      ? "教員"
-                      : "その他"}
+                        ? "生徒"
+                        : guestInfo.guest_type === "teacher"
+                          ? "教員"
+                          : "その他"}
                   </ListItemText>
                 </ListItem>
                 <ListItem>

--- a/src/components/page/Analytics/Exhibit.tsx
+++ b/src/components/page/Analytics/Exhibit.tsx
@@ -69,20 +69,19 @@ const AnalyticsExhibit: React.VFC = () => {
         </Grid>
       ) : (
         <Grid container spacing={2}>
-          <Grid
-            item
-            xs={12}
-          >
-            <Box sx={{
-              width: "100%",
-              display: "flex",
-              overflowX: "scroll",
-              flexDirection: "row",
-              justifyContent: largerThanSM ? "flex-end" : "flex-start",
-              alignItems: "center",
-              whiteSpace: "nowrap",
-              p: 0,
-            }} >
+          <Grid item xs={12}>
+            <Box
+              sx={{
+                width: "100%",
+                display: "flex",
+                overflowX: "scroll",
+                flexDirection: "row",
+                justifyContent: largerThanSM ? "flex-end" : "flex-start",
+                alignItems: "center",
+                whiteSpace: "nowrap",
+                p: 0,
+              }}
+            >
               <Box sx={{ display: "flex", gap: 1 }}>
                 {profile?.user_type === "moderator" && (
                   <Button
@@ -118,7 +117,8 @@ const AnalyticsExhibit: React.VFC = () => {
                 >
                   退室スキャン
                 </Button>
-              </Box></Box>
+              </Box>
+            </Box>
           </Grid>
           <Grid item xs={12} lg={6}>
             <ExhibitCurrentGuestList exhibit_id={exhibitId} />

--- a/src/components/page/Analytics/Exhibit.tsx
+++ b/src/components/page/Analytics/Exhibit.tsx
@@ -72,7 +72,8 @@ const AnalyticsExhibit: React.VFC = () => {
           <Grid
             item
             xs={12}
-            sx={{
+          >
+            <Box sx={{
               width: "100%",
               display: "flex",
               overflowX: "scroll",
@@ -81,45 +82,43 @@ const AnalyticsExhibit: React.VFC = () => {
               alignItems: "center",
               whiteSpace: "nowrap",
               p: 0,
-              pb: largerThanSM ? 0 : 1,
-            }}
-          >
-            <Box sx={{ display: "flex", gap: 1 }}>
-              {profile?.user_type === "moderator" && (
+            }} >
+              <Box sx={{ display: "flex", gap: 1 }}>
+                {profile?.user_type === "moderator" && (
+                  <Button
+                    startIcon={<ArrowBackIosNewRoundedIcon />}
+                    onClick={() => navigate("/exhibit/", { replace: true })}
+                  >
+                    展示選択
+                  </Button>
+                )}
+                {profile?.user_type === "moderator" && (
+                  <Button
+                    startIcon={<ArrowBackIosNewRoundedIcon />}
+                    onClick={() =>
+                      navigate("/analytics/summary", { replace: true })
+                    }
+                  >
+                    展示一覧
+                  </Button>
+                )}
                 <Button
-                  startIcon={<ArrowBackIosNewRoundedIcon />}
-                  onClick={() => navigate("/exhibit/", { replace: true })}
-                >
-                  展示選択
-                </Button>
-              )}
-              {profile?.user_type === "moderator" && (
-                <Button
-                  startIcon={<ArrowBackIosNewRoundedIcon />}
+                  startIcon={<LoginRoundedIcon />}
                   onClick={() =>
-                    navigate("/analytics/summary", { replace: true })
+                    navigate(`/exhibit/${exhibitId}/enter`, { replace: true })
                   }
                 >
-                  展示一覧
+                  入室スキャン
                 </Button>
-              )}
-              <Button
-                startIcon={<LoginRoundedIcon />}
-                onClick={() =>
-                  navigate(`/exhibit/${exhibitId}/enter`, { replace: true })
-                }
-              >
-                入室スキャン
-              </Button>
-              <Button
-                startIcon={<LogoutRoundedIcon />}
-                onClick={() =>
-                  navigate(`/exhibit/${exhibitId}/exit`, { replace: true })
-                }
-              >
-                退室スキャン
-              </Button>
-            </Box>
+                <Button
+                  startIcon={<LogoutRoundedIcon />}
+                  onClick={() =>
+                    navigate(`/exhibit/${exhibitId}/exit`, { replace: true })
+                  }
+                >
+                  退室スキャン
+                </Button>
+              </Box></Box>
           </Grid>
           <Grid item xs={12} lg={6}>
             <ExhibitCurrentGuestList exhibit_id={exhibitId} />

--- a/src/components/page/Analytics/Index.tsx
+++ b/src/components/page/Analytics/Index.tsx
@@ -9,7 +9,7 @@ import RealtimeLog from "#/components/block/RealtimeLog";
 
 const AnalyticsIndex: React.VFC = () => {
   setTitle("滞在状況");
-  const { largerThanMD } = useDeviceWidth();
+  const { largerThanLG } = useDeviceWidth();
 
   return (
     <Grid
@@ -17,13 +17,14 @@ const AnalyticsIndex: React.VFC = () => {
       spacing={2}
       sx={{
         flexWrap: "nowrap",
-        flexDirection: largerThanMD ? "row" : "column-reverse",
+        flexDirection: largerThanLG ? "row" : "column-reverse",
+        justifyContent: "space-between",
       }}
     >
-      <Grid item xs={12} md={8}>
+      <Grid item xs={12} lg={7}>
         <RealtimeLog />
       </Grid>
-      <Grid item xs={12} md={4}>
+      <Grid item xs={12} lg={4}>
         <AllAreaPieChart />
       </Grid>
     </Grid>

--- a/src/components/page/Analytics/Summary.tsx
+++ b/src/components/page/Analytics/Summary.tsx
@@ -177,16 +177,16 @@ const AnalyticsSummary: React.VFC = () => {
       sx={
         expand
           ? {
-              position: "fixed",
-              top: 0,
-              left: 0,
-              height: "100vh",
-              overflowY: "scroll",
-              my: 0,
-              px: 1,
-              backgroundColor: "white",
-              transform: "translateZ(3px)",
-            }
+            position: "fixed",
+            top: 0,
+            left: 0,
+            height: "100vh",
+            overflowY: "scroll",
+            my: 0,
+            px: 1,
+            backgroundColor: "white",
+            transform: "translateZ(3px)",
+          }
           : null
       }
     >

--- a/src/components/page/Analytics/Summary.tsx
+++ b/src/components/page/Analytics/Summary.tsx
@@ -177,16 +177,16 @@ const AnalyticsSummary: React.VFC = () => {
       sx={
         expand
           ? {
-            position: "fixed",
-            top: 0,
-            left: 0,
-            height: "100vh",
-            overflowY: "scroll",
-            my: 0,
-            px: 1,
-            backgroundColor: "white",
-            transform: "translateZ(3px)",
-          }
+              position: "fixed",
+              top: 0,
+              left: 0,
+              height: "100vh",
+              overflowY: "scroll",
+              my: 0,
+              px: 1,
+              backgroundColor: "white",
+              transform: "translateZ(3px)",
+            }
           : null
       }
     >

--- a/src/components/page/Entrance/Enter.tsx
+++ b/src/components/page/Entrance/Enter.tsx
@@ -34,6 +34,7 @@ import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
 import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ReplayRoundedIcon from "@mui/icons-material/ReplayRounded";
+import AssignmentRoundedIcon from '@mui/icons-material/AssignmentRounded';
 
 import {
   getTimePart,
@@ -161,8 +162,7 @@ const EntranceEnter: React.VFC = () => {
           })
           .then(() => {
             setDialogMessage(
-              `予約ID: ${reservation.reservation_id}へ${
-                guestList.length
+              `予約ID: ${reservation.reservation_id}へ${guestList.length
               }つのリストバンド(${guestList.join(
                 ", "
               )})の紐付けが完了しました。`
@@ -342,6 +342,11 @@ const EntranceEnter: React.VFC = () => {
             >
               <ReservationInfoCard />
             </SwipeableDrawer>
+          )}
+          {!largerThanSM && (
+            <Box sx={{ textAlign: "center", mb: 2 }}>
+              <Button variant="text" onClick={() => setSMDrawerOpen(true)} startIcon={<AssignmentRoundedIcon />}>スキャンしたリストバンドを表示</Button>
+            </Box>
           )}
           {reservation && (
             <Card variant="outlined" sx={{ my: 1, p: 2 }}>

--- a/src/components/page/Entrance/Enter.tsx
+++ b/src/components/page/Entrance/Enter.tsx
@@ -216,12 +216,11 @@ const EntranceEnter: React.VFC = () => {
               sx={{ my: 1, mx: !largerThanMD ? 1 : 0, p: 2 }}
             >
               <Typography variant="h4">リストバンド</Typography>
-              {guestList.length === 0 && (
+              {guestList.length === 0 ? (
                 <Typography variant="body1" sx={{ p: 2 }}>
                   ここに予約と紐づけるリストバンドのIDが表示されます
                 </Typography>
-              )}
-              {guestList.length !== 0 && (
+              ) : (
                 <>
                   <List dense>
                     {guestList.map((guest, index) => (

--- a/src/components/page/Entrance/Enter.tsx
+++ b/src/components/page/Entrance/Enter.tsx
@@ -34,7 +34,7 @@ import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
 import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ReplayRoundedIcon from "@mui/icons-material/ReplayRounded";
-import AssignmentRoundedIcon from '@mui/icons-material/AssignmentRounded';
+import AssignmentRoundedIcon from "@mui/icons-material/AssignmentRounded";
 
 import {
   getTimePart,
@@ -162,7 +162,8 @@ const EntranceEnter: React.VFC = () => {
           })
           .then(() => {
             setDialogMessage(
-              `予約ID: ${reservation.reservation_id}へ${guestList.length
+              `予約ID: ${reservation.reservation_id}へ${
+                guestList.length
               }つのリストバンド(${guestList.join(
                 ", "
               )})の紐付けが完了しました。`
@@ -344,7 +345,13 @@ const EntranceEnter: React.VFC = () => {
           )}
           {!largerThanSM && (
             <Box sx={{ textAlign: "center", mb: 2 }}>
-              <Button variant="text" onClick={() => setSMDrawerOpen(true)} startIcon={<AssignmentRoundedIcon />}>スキャンしたリストバンドを表示</Button>
+              <Button
+                variant="text"
+                onClick={() => setSMDrawerOpen(true)}
+                startIcon={<AssignmentRoundedIcon />}
+              >
+                スキャンしたリストバンドを表示
+              </Button>
             </Box>
           )}
           {reservation && (

--- a/src/components/page/Exhibit/ExhibitScan.tsx
+++ b/src/components/page/Exhibit/ExhibitScan.tsx
@@ -156,7 +156,8 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                   // すでに該当の展示に入室中の場合
                   setScanStatus("error");
                   setAlertMessage(
-                    `このゲストはすでに${exhibitName ? `「${exhibitName}」` : "この展示"
+                    `このゲストはすでに${
+                      exhibitName ? `「${exhibitName}」` : "この展示"
                     }に入室中です。退室スキャンと間違えていませんか？`
                   );
                   ReactGA.event({
@@ -217,7 +218,8 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                   // どこの展示にも入室していない
                   setScanStatus("error");
                   setAlertMessage(
-                    `このゲストの${exhibitName ? `「${exhibitName}」` : "この展示"
+                    `このゲストの${
+                      exhibitName ? `「${exhibitName}」` : "この展示"
                     }への入室記録がありません。入室スキャンと間違えていませんか？`
                   );
                   ReactGA.event({
@@ -229,7 +231,8 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                   // 別の展示に入室中
                   setScanStatus("success");
                   setAlertMessage(
-                    `このゲストは他の展示に入室中です。まずは${exhibitName ? `「${exhibitName}」` : "この展示"
+                    `このゲストは他の展示に入室中です。まずは${
+                      exhibitName ? `「${exhibitName}」` : "この展示"
                     }への入室スキャンをしてください。`
                   );
                   ReactGA.event({
@@ -273,7 +276,8 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
   useEffect(() => {
     if (scanStatus === "success") {
       setGuideMessage(
-        `情報を確認し、問題がなければ${scanType === "enter" ? "入室記録" : "退室記録"
+        `情報を確認し、問題がなければ${
+          scanType === "enter" ? "入室記録" : "退室記録"
         }を押してください`
       );
     }
@@ -375,10 +379,10 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                     guestInfo.guest_type === "student"
                       ? "生徒"
                       : guestInfo.guest_type === "teacher"
-                        ? "教員"
-                        : guestInfo.guest_type === "family"
-                          ? "保護者"
-                          : "その他"
+                      ? "教員"
+                      : guestInfo.guest_type === "family"
+                      ? "保護者"
+                      : "その他"
                   }
                 />
               </ListItem>
@@ -449,28 +453,26 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                   {scanType === "enter" ? "入室スキャン" : "退室スキャン"}
                 </Typography>
               </Grid>
-              <Grid
-                item
-                flexGrow={1}
-                xs={12}
-                sm
-              >
-                <Box sx={{
-                  width: "100%",
-                  display: "flex",
-                  overflowX: "scroll",
-                  flexDirection: "row",
-                  justifyContent: largerThanSM ? "flex-end" : "flex-start",
-                  alignItems: "center",
-                  whiteSpace: "nowrap",
-                  p: 0,
-                }}>
+              <Grid item flexGrow={1} xs={12} sm>
+                <Box
+                  sx={{
+                    width: "100%",
+                    display: "flex",
+                    overflowX: "scroll",
+                    flexDirection: "row",
+                    justifyContent: largerThanSM ? "flex-end" : "flex-start",
+                    alignItems: "center",
+                    whiteSpace: "nowrap",
+                    p: 0,
+                  }}
+                >
                   <Box sx={{ display: "flex", gap: 1 }}>
                     <Button
                       startIcon={<PublishedWithChangesRoundedIcon />}
                       onClick={() =>
                         navigate(
-                          `/exhibit/${exhibitId || "unknown"}/${scanType === "enter" ? "exit" : "enter"
+                          `/exhibit/${exhibitId || "unknown"}/${
+                            scanType === "enter" ? "exit" : "enter"
                           } `,
                           { replace: true }
                         )
@@ -492,10 +494,14 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                         </Button>
                       )}
                     {profile &&
-                      ["moderator", "executive"].includes(profile.user_type) && (
+                      ["moderator", "executive"].includes(
+                        profile.user_type
+                      ) && (
                         <Button
                           startIcon={<ArrowBackIosNewRoundedIcon />}
-                          onClick={() => navigate("/exhibit", { replace: true })}
+                          onClick={() =>
+                            navigate("/exhibit", { replace: true })
+                          }
                         >
                           一覧に戻る
                         </Button>

--- a/src/components/page/Exhibit/ExhibitScan.tsx
+++ b/src/components/page/Exhibit/ExhibitScan.tsx
@@ -156,8 +156,7 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                   // すでに該当の展示に入室中の場合
                   setScanStatus("error");
                   setAlertMessage(
-                    `このゲストはすでに${
-                      exhibitName ? `「${exhibitName}」` : "この展示"
+                    `このゲストはすでに${exhibitName ? `「${exhibitName}」` : "この展示"
                     }に入室中です。退室スキャンと間違えていませんか？`
                   );
                   ReactGA.event({
@@ -218,8 +217,7 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                   // どこの展示にも入室していない
                   setScanStatus("error");
                   setAlertMessage(
-                    `このゲストの${
-                      exhibitName ? `「${exhibitName}」` : "この展示"
+                    `このゲストの${exhibitName ? `「${exhibitName}」` : "この展示"
                     }への入室記録がありません。入室スキャンと間違えていませんか？`
                   );
                   ReactGA.event({
@@ -231,8 +229,7 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                   // 別の展示に入室中
                   setScanStatus("success");
                   setAlertMessage(
-                    `このゲストは他の展示に入室中です。まずは${
-                      exhibitName ? `「${exhibitName}」` : "この展示"
+                    `このゲストは他の展示に入室中です。まずは${exhibitName ? `「${exhibitName}」` : "この展示"
                     }への入室スキャンをしてください。`
                   );
                   ReactGA.event({
@@ -276,8 +273,7 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
   useEffect(() => {
     if (scanStatus === "success") {
       setGuideMessage(
-        `情報を確認し、問題がなければ${
-          scanType === "enter" ? "入室記録" : "退室記録"
+        `情報を確認し、問題がなければ${scanType === "enter" ? "入室記録" : "退室記録"
         }を押してください`
       );
     }
@@ -379,10 +375,10 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                     guestInfo.guest_type === "student"
                       ? "生徒"
                       : guestInfo.guest_type === "teacher"
-                      ? "教員"
-                      : guestInfo.guest_type === "family"
-                      ? "保護者"
-                      : "その他"
+                        ? "教員"
+                        : guestInfo.guest_type === "family"
+                          ? "保護者"
+                          : "その他"
                   }
                 />
               </ListItem>
@@ -458,7 +454,8 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                 flexGrow={1}
                 xs={12}
                 sm
-                sx={{
+              >
+                <Box sx={{
                   width: "100%",
                   display: "flex",
                   overflowX: "scroll",
@@ -467,45 +464,43 @@ const ExhibitScan: React.VFC<{ scanType: "enter" | "exit" }> = ({
                   alignItems: "center",
                   whiteSpace: "nowrap",
                   p: 0,
-                  pb: largerThanSM ? 0 : 1,
-                }}
-              >
-                <Box sx={{ display: "flex", gap: 1 }}>
-                  <Button
-                    startIcon={<PublishedWithChangesRoundedIcon />}
-                    onClick={() =>
-                      navigate(
-                        `/exhibit/${exhibitId || "unknown"}/${
-                          scanType === "enter" ? "exit" : "enter"
-                        } `,
-                        { replace: true }
-                      )
-                    }
-                  >
-                    {scanType === "enter" ? "退室スキャン" : "入室スキャン"}
-                  </Button>
-                  {profile &&
-                    ["moderator", "exhibit"].includes(profile.user_type) && (
-                      <Button
-                        startIcon={<BarChartRoundedIcon />}
-                        onClick={() =>
-                          navigate(`/analytics/exhibit/${exhibitId}`, {
-                            replace: true,
-                          })
-                        }
-                      >
-                        滞在状況
-                      </Button>
-                    )}
-                  {profile &&
-                    ["moderator", "executive"].includes(profile.user_type) && (
-                      <Button
-                        startIcon={<ArrowBackIosNewRoundedIcon />}
-                        onClick={() => navigate("/exhibit", { replace: true })}
-                      >
-                        一覧に戻る
-                      </Button>
-                    )}
+                }}>
+                  <Box sx={{ display: "flex", gap: 1 }}>
+                    <Button
+                      startIcon={<PublishedWithChangesRoundedIcon />}
+                      onClick={() =>
+                        navigate(
+                          `/exhibit/${exhibitId || "unknown"}/${scanType === "enter" ? "exit" : "enter"
+                          } `,
+                          { replace: true }
+                        )
+                      }
+                    >
+                      {scanType === "enter" ? "退室スキャン" : "入室スキャン"}
+                    </Button>
+                    {profile &&
+                      ["moderator", "exhibit"].includes(profile.user_type) && (
+                        <Button
+                          startIcon={<BarChartRoundedIcon />}
+                          onClick={() =>
+                            navigate(`/analytics/exhibit/${exhibitId}`, {
+                              replace: true,
+                            })
+                          }
+                        >
+                          滞在状況
+                        </Button>
+                      )}
+                    {profile &&
+                      ["moderator", "executive"].includes(profile.user_type) && (
+                        <Button
+                          startIcon={<ArrowBackIosNewRoundedIcon />}
+                          onClick={() => navigate("/exhibit", { replace: true })}
+                        >
+                          一覧に戻る
+                        </Button>
+                      )}
+                  </Box>
                 </Box>
               </Grid>
             </Grid>

--- a/src/components/page/Exhibit/Index.tsx
+++ b/src/components/page/Exhibit/Index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAtomValue } from "jotai";
 import { profileAtom, setTitle } from "#/components/lib/jotai";
@@ -19,7 +19,11 @@ const ExhibitIndex: React.VFC = () => {
   setTitle("展示選択");
   const navigate = useNavigate();
   const profile = useAtomValue(profileAtom);
-  const [currentExhibit, setCurrentExhibit] = useState<string>("");
+  const [currentExhibit, setCurrentExhibit] = useState<string>(localStorage.getItem("currentExhibit") || "");
+
+  useEffect(() => {
+    localStorage.setItem("currentExhibit", currentExhibit);
+  }, [currentExhibit]);
 
   return (
     <Grid container spacing={2}>

--- a/src/components/page/Exhibit/Index.tsx
+++ b/src/components/page/Exhibit/Index.tsx
@@ -19,7 +19,9 @@ const ExhibitIndex: React.VFC = () => {
   setTitle("展示選択");
   const navigate = useNavigate();
   const profile = useAtomValue(profileAtom);
-  const [currentExhibit, setCurrentExhibit] = useState<string>(localStorage.getItem("currentExhibit") || "");
+  const [currentExhibit, setCurrentExhibit] = useState<string>(
+    localStorage.getItem("currentExhibit") || ""
+  );
 
   useEffect(() => {
     localStorage.setItem("currentExhibit", currentExhibit);

--- a/src/components/page/Login.tsx
+++ b/src/components/page/Login.tsx
@@ -157,6 +157,11 @@ const Login: React.VFC = () => {
                             </InputAdornment>
                           ),
                         }}
+                        sx={{
+                          '& *::-ms-reveal': {
+                            display: "none",
+                          }
+                        }}
                       />
                     </Grid>
                     <Grid

--- a/src/components/page/Login.tsx
+++ b/src/components/page/Login.tsx
@@ -158,9 +158,9 @@ const Login: React.VFC = () => {
                           ),
                         }}
                         sx={{
-                          '& *::-ms-reveal': {
+                          "& *::-ms-reveal": {
                             display: "none",
-                          }
+                          },
                         }}
                       />
                     </Grid>


### PR DESCRIPTION
- 「全体の滞在状況」でゲスト種別ごとの人数を表示
- Microsoft Edgeでログイン画面のパスワード表示ボタンが二重に表示される不具合を修正
- エントランスリストバンド紐付け処理の画面をスマホで表示した時SwipableDrawerを表示するボタンを追加
- ログメッセージにユーザーエージェントを表示
- リアルタイムログで常に「入室」と表示される不具合を修正
- 展示選択で選択した展示の状態を保存